### PR TITLE
docs(env): clarify acme DEFAULT_EMAIL vs per-container LETSENCRYPT_EMAIL

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,5 @@
+# nginx-proxy: comma-separated hostnames. For Let's Encrypt via userver-web acme-companion, set
+# DEFAULT_EMAIL once in letsencrypt/.env; avoid repeating LETSENCRYPT_EMAIL on every service.
 VIRTUAL_HOST=<public-domain1>,<public-domain2>,<public-domain3>
 DEMO_DEPLOY_BUCKET=<bucket-name>
 DEMO_DEPLOY_REGION=<bucket-region>


### PR DESCRIPTION
Document that repeating the same email on many containers breaks ACME when using userver-web nginx-proxy / acme-companion (addresses get concatenated).

Made-with: Cursor

## Summary

<!-- What changed and why (short bullet list). -->

## Checklist

- [ ] Changes match existing shell/nginx style where applicable
- [ ] `shellcheck` passes on any edited scripts (see Codebase Quality workflow)
- [ ] Docker E2E / local `docker compose` still works if you touched compose or the image
- [ ] No secrets or credentials committed (GitLeaks workflow)

Thank you for contributing.
